### PR TITLE
Add IO.todo as a replacement for return null placeholders in labs

### DIFF
--- a/lib/src/main/java/jtamaro/en/IO.java
+++ b/lib/src/main/java/jtamaro/en/IO.java
@@ -149,6 +149,11 @@ public final class IO {
    * @param color the color to show
    */
   public static void show(Color color) {
+    if (color == null) {
+      System.err.println("Nothing to show");
+      return;
+    }
+
     SwingUtilities.invokeLater(() -> {
       final ColorFrame frame = new ColorFrame(color.getImplementation());
       frame.setVisible(true);
@@ -161,6 +166,11 @@ public final class IO {
    * @param graphic the graphic to show
    */
   public static void show(Graphic graphic) {
+    if (graphic == null) {
+      System.err.println("Nothing to show");
+      return;
+    }
+
     SwingUtilities.invokeLater(() -> {
       final GraphicFrame frame = new GraphicFrame();
       frame.setGraphic(((AbstractGraphic) graphic).getImplementation());
@@ -236,6 +246,11 @@ public final class IO {
    * @param millisecondsPerFrame delay between frames
    */
   public static void animate(Sequence<Graphic> graphics, boolean loop, int millisecondsPerFrame) {
+    if (graphics == null) {
+      System.err.println("Nothing to animate");
+      return;
+    }
+
     assert !graphics.isEmpty() : "Animation must have at least one frame";
     assert millisecondsPerFrame > 0 : "Must wait a positive number of milliseconds between frames";
     final Pair<Integer, Integer> wh = determineMaxWidthHeight(graphics);
@@ -282,6 +297,11 @@ public final class IO {
    * @param frameHeight the height of frames (should be at least the maximum of all the graphics' heights)
    */
   public static void showFilmStrip(Sequence<Graphic> graphics, int frameWidth, int frameHeight) {
+    if (graphics == null) {
+      System.err.println("Nothing to show");
+      return;
+    }
+
     assert frameWidth >= 0 : "Can't have a negative width";
     assert frameHeight >= 0 : "Can't have a negative height";
     SwingUtilities.invokeLater(() -> {


### PR DESCRIPTION
Example usage:

<img width="632" alt="image" src="https://github.com/LuCEresearchlab/jtamaro/assets/16168055/555076df-d7a6-4b95-b9d6-535a7a6e3574">
